### PR TITLE
Add CodeClimate to README and Circle Config

### DIFF
--- a/.circle-ci/circle.yml
+++ b/.circle-ci/circle.yml
@@ -1,6 +1,33 @@
+version: 2.0
 database:
   override:
     - RAILS_ENV=development
 test:
   override:
     - COVERAGE=true
+jobs:
+  build:
+    environment:
+      CC_TEST_REPORTER_ID: $CC_TEST_REPORTER_ID
+    docker:
+      - image: circleci/php:7.1.9-browsers
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: Setup dependencies
+          command: |
+            sudo composer self-update
+            composer install -n --prefer-dist
+      - run:
+          name: Setup Code Climate test-reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+      - run:
+          name: Run tests
+          command: |
+            sudo docker-php-ext-enable xdebug
+            ./cc-test-reporter before-build
+            sudo vendor/bin/phpunit --coverage-clover clover.xml
+            ./cc-test-reporter after-build --coverage-input-type clover --exit-cod

--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 [Visit the website](http://www.spinacms.com)
 
 [![Spina Articles Build Status](https://circleci.com/gh/lukad03/spina-articles.svg?style=svg)](https://circleci.com/gh/lukad03/spina-articles)
+[![Maintainability](https://api.codeclimate.com/v1/badges/b0199ecbb559623aafb1/maintainability)](https://codeclimate.com/github/lukad03/spina-articles/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/b0199ecbb559623aafb1/test_coverage)](https://codeclimate.com/github/lukad03/spina-articles/test_coverage)
 
 # Getting Started
 
-This is a News/Blog plugin for Spina CMS based on articles.
+This is a plugin for Spina CMS that adds Articles as a publishable content type.
 
 ```
 gem 'spina-articles'


### PR DESCRIPTION
Adds CodeClimate badges to README. Also adds test coverage hook to CircleCI config to send test coverage results to CodeClimate.

* Add CodeClimate maintainability badge to README
* Add CodeClimate test coverage badge to README
* Add hook to test in CircleCI config that sends test coverage info to CodeClimate